### PR TITLE
perf(web): SSE のメモリリーク解消とタブ非表示時の処理停止

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,9 @@ export default function App() {
   );
 }
 
+// タブ非表示が続いたら SSE を切断するまでの猶予。短いタブ切替で切断/再接続を繰り返さないため。
+const SSE_HIDDEN_GRACE_MS = 15000;
+
 function Shell({
   onLogout,
   onRestarting,
@@ -65,7 +68,10 @@ function Shell({
   const [focusedIdx, setFocusedIdx] = useState(0);
   const [activeTab, setActiveTab] = useState<TabId>("session");
   const [navOpened, setNavOpened] = useState(false);
-  const seenSeq = useRef<Set<number>>(new Set());
+  // SSE ログの重複除去。seq はサーバー側で単調増加（driver.publishLog）なので「見た最大 seq」
+  // 1つだけ覚えれば足りる（Set 全件保持は無制限に増えるため不可）。再接続時の履歴再送（重複 seq）も
+  // これで弾け、取りこぼした新しい行は履歴から復旧できる。
+  const lastSeq = useRef(0); // seq は 1 始まり。0 は安全な番兵
   // 中央 Resonite アカウントの設定状態（初回モーダル + 未設定バナーを駆動）。
   // null=未取得/取得失敗（バナー出さず）。取得成功して username+password が揃えば false。
   const [credUnset, setCredUnset] = useState<boolean | null>(null);
@@ -92,19 +98,49 @@ function Shell({
   }, [status, t]);
 
   // SSE（status + log）をシェル最上位で購読し、トップバーのモードとログを駆動。
+  // タブ非表示中は接続ごと閉じ、受信・JSON解析・再レンダリングを完全停止する（見ていない間の
+  // 無駄処理を止める）。再表示で張り直すと、サーバーが接続直後に現在 status＋直近履歴を再送する
+  // ため画面は即追いつき、lastSeq の重複除去で行は重複しない（logs は表示専用で、取りこぼしても
+  // ディスクの Logs タブに全量が残る）。useVisiblePolling と同じ Page Visibility 連動。
   useEffect(() => {
-    const es = new EventSource("/api/v1/events");
-    es.addEventListener("status", (e) => setStatus(JSON.parse((e as MessageEvent).data) as Status));
-    es.addEventListener("log", (e) => {
-      const line = JSON.parse((e as MessageEvent).data) as LogLine;
-      if (seenSeq.current.has(line.seq)) return;
-      seenSeq.current.add(line.seq);
-      setLogs((prev) => {
-        const next = [...prev, line];
-        return next.length > 1000 ? next.slice(next.length - 1000) : next;
+    let es: EventSource | null = null;
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const connect = () => {
+      if (es) return; // 既に接続中（猶予中に戻ってきた等）
+      es = new EventSource("/api/v1/events");
+      es.addEventListener("status", (e) => setStatus(JSON.parse((e as MessageEvent).data) as Status));
+      es.addEventListener("log", (e) => {
+        const line = JSON.parse((e as MessageEvent).data) as LogLine;
+        if (line.seq <= lastSeq.current) return; // 既読（履歴再送の重複等）は捨てる
+        lastSeq.current = line.seq;
+        setLogs((prev) => {
+          const next = [...prev, line];
+          return next.length > 1000 ? next.slice(next.length - 1000) : next;
+        });
       });
-    });
-    return () => es.close();
+    };
+    const disconnect = () => {
+      es?.close();
+      es = null;
+    };
+    const onVisibility = () => {
+      clearTimeout(closeTimer);
+      if (document.hidden) {
+        closeTimer = setTimeout(disconnect, SSE_HIDDEN_GRACE_MS); // 猶予後に切断
+      } else {
+        connect(); // 再表示で即再接続（現在 status＋履歴を再取得）
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+    if (!document.hidden) connect();
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      clearTimeout(closeTimer);
+      disconnect();
+    };
   }, []);
 
   // 停止中トップバーの config 選択肢。コンフィグタブの CRUD 後にも再取得する（ConfigTab に渡す）。


### PR DESCRIPTION
## 背景
「長時間稼働で重くなる / メモリリーク / ブラウザ非表示でも無駄に動き続けないか」の調査で見つかった2点を修正します。バックエンドは調査の結果リーク・暴走なし（有界リングバッファ・イベント駆動ワーカー・アクセス駆動メトリクス・ステートレス認証）のため**変更なし**。修正はフロント `web/src/App.tsx` のみです。

> 注: 前回 PR #2（自己更新まわり）はマージ済みのため、本 PR の差分はこの perf コミット1件だけです。

## 変更点

### 1. 重複除去 `seenSeq` の無制限メモリリーク（最優先）
ログ1行ごとに `seq` を `Set` へ追加し続け、解放されず単調増加していた（長時間・大量ログでタブのメモリ肥大＋GC 圧で重くなる主因）。
`seq` はサーバー側（`driver.publishLog`）で単調増加するため「見た最大 seq」1つを持てば重複除去は成立する。`Set` を `lastSeq`（数値1個）の high-water mark 方式へ置換し **O(1)** 化。
- 再接続時の履歴再送（重複 seq）も `<=` 判定で弾ける。
- 取りこぼした新しい行は履歴から復旧できる（Set 版と同挙動）。
- `seq` が下がるのは mrhc プロセス再起動時のみ＝その時はページがリロードされ ref も初期化されるので安全。

### 2. タブ非表示中も SSE が動き続ける無駄処理（次点）
`EventSource` は非表示でも切れないため、見ていない間もログ受信・JSON 解析・`App` 再レンダリングが継続していた。
既存 `useVisiblePolling` と同じ Page Visibility 連動にし、**非表示が15秒続いたら接続を閉じて全停止**、**再表示で即再接続**する（猶予はタブ切替の連続切断/再接続を避けるため）。
- 再接続時はサーバーが接続直後に現在 `status`＋直近履歴を再送するため画面は即追いつく。`lastSeq` の重複除去で行は重複しない。
- `logs` は表示専用（解析・ロジックなし。ログイン/ready/fault は別系統の `status`、永続ログは Logs タブのディスク経由）。非表示中にライブ行を取りこぼしても**機能影響はなく、全量はディスクに残る**。

## 割り切り（合意済み）
- 15秒超離席して戻ると、非表示中のログのうち履歴256行に乗らない分はライブコンソールに出ない（ライブ tail の仕様。全量は Logs タブにあり）。
- 非表示中に出た `duplicate_instance` 等のトーストは、再表示で fault が残っていれば出る／一時的に消えていれば出ない。

## 検証
- `tsc --noEmit` クリーン / 本番ビルド成功 / `seenSeq` 参照ゼロ。
- サーバー側 `/events` は無変更。再接続の重複除去は `SubscribeLog`（チャネル登録→履歴スナップショット順）＋ `lastSeq` がコードレビューで Set 版と同挙動と確認済み。
- 実ブラウザの `visibilitychange` 挙動は標準 DOM API（既存 `useVisiblePolling` と同パターン）。

## 既知の低リスク点（任意の堅牢化・未対応）
- bfcache 復帰（別 URL へ遷移→戻る）で `visibilitychange(visible)` が発火しないブラウザでは切断状態に留まる可能性。SPA では稀で既存 `useVisiblePolling` も同前提のため新規欠陥ではない。必要なら `pageshow`/`focus` でも再接続する一行で塞げる。

https://claude.ai/code/session_01XpCE5eMzbFQ6FjetwPcaVi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpCE5eMzbFQ6FjetwPcaVi)_